### PR TITLE
Switches -v tests with more compatible version

### DIFF
--- a/F
+++ b/F
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Editor: if SACK_EDITOR is not defined, take the default editor.
-if [ -v SACK_EDITOR ]; then
+if [ ! -z ${SACK_EDITOR+x} ]; then
     editor=$SACK_EDITOR
 else
     editor=$EDITOR
@@ -9,7 +9,7 @@ fi
 
 # Sack shortcut file. '.~/.sack_shortcurt' if the variable SACK_SHORTCUT is not
 # defined.
-if [ -v SACK_SHORTCUT ]; then
+if [ ! -z ${SACK_SHORTCUT+x} ]; then
     sack_shortcutfile=$SACK_SHORTCUT
 else
     sack_shortcutfile=~/.sack_shortcuts

--- a/sack
+++ b/sack
@@ -98,7 +98,7 @@ fi
 
 # Sack shortcut file. '.~/.sack_shortcurt' if the variable SACK_SHORTCUT is not
 # defined.
-if [ -v SACK_SHORTCUT ]; then
+if [ ! -z ${SACK_SHORTCUT+x} ]; then
     sack__shortcut_file=$SACK_SHORTCUT
 else
     sack__shortcut_file=~/.sack_shortcuts


### PR DESCRIPTION
Testing to check if a variable is defined with tests like
`[ -v SACK_SHORTCUT ]` was added in bash 4.2. Replaced such tests
with tests of the following kind: `[ ! -z ${SACK_SHORTCUT+x} ]`,
which work in older versions of bash as well.

Details of how this syntax works:
http://stackoverflow.com/a/13864829/3347227
